### PR TITLE
Improve performance of EventAdapter and it views

### DIFF
--- a/app/src/main/java/com/alorma/github/ui/adapter/detail/repo/RepoSourceAdapter.java
+++ b/app/src/main/java/com/alorma/github/ui/adapter/detail/repo/RepoSourceAdapter.java
@@ -54,9 +54,10 @@ public class RepoSourceAdapter extends ArrayAdapter<Content> {
 			iconDrawable = new IconicsDrawable(context, Octicons.Icon.oct_file_text);
 		}
 
-		if (iconDrawable != null) {
-			iconDrawable.sizeDp(20);
-			iconDrawable.color(AttributesUtils.getPrimaryLightColor(getContext()));
+        if (iconDrawable != null) {
+            iconDrawable.sizeDp(36);
+            iconDrawable.paddingDp(8);
+            iconDrawable.color(AttributesUtils.getPrimaryLightColor(getContext()));
 
 			image.setImageDrawable(iconDrawable);
 		}

--- a/app/src/main/java/com/alorma/github/ui/adapter/events/EventAdapter.java
+++ b/app/src/main/java/com/alorma/github/ui/adapter/events/EventAdapter.java
@@ -40,9 +40,19 @@ public class EventAdapter extends LazyAdapter<GithubEvent> {
     public View getView(int position, View convertView, ViewGroup parent) {
         GithubEvent githubEvent = getItem(position);
 
-        View v = inflate(githubEvent);
+        //get the viewHolder
+        ViewHolder viewHolder;
+        if (convertView == null) {
+            convertView = inflate(githubEvent);
+            viewHolder = new ViewHolder((GithubEventView) convertView);
+            convertView.setTag(viewHolder);
+        } else {
+            viewHolder = (ViewHolder) convertView.getTag();
+        }
 
-        return v;
+        //here it will get populated :O
+        viewHolder.view.setEvent(githubEvent);
+        return convertView;
     }
 
     public View inflate(GithubEvent event) {
@@ -72,9 +82,17 @@ public class EventAdapter extends LazyAdapter<GithubEvent> {
             v = new UnhandledEventView(getContext());
         }
 
-        v.setEvent(event);
-
         return v;
+    }
+
+    @Override
+    public int getItemViewType(int position) {
+        return getItem(position).getType().ordinal();
+    }
+
+    @Override
+    public int getViewTypeCount() {
+        return EventType.values().length;
     }
 
     @Override
@@ -111,5 +129,13 @@ public class EventAdapter extends LazyAdapter<GithubEvent> {
                 || (event.getType() == EventType.ReleaseEvent)
                 || (event.getType() == EventType.PullRequestEvent)
                 || (event.getType() == EventType.DeleteEvent);
+    }
+
+    private static class ViewHolder {
+        private GithubEventView view;
+
+        private ViewHolder(GithubEventView view) {
+            this.view = view;
+        }
     }
 }

--- a/app/src/main/java/com/alorma/github/ui/adapter/events/views/CommitCommentEventView.java
+++ b/app/src/main/java/com/alorma/github/ui/adapter/events/views/CommitCommentEventView.java
@@ -44,7 +44,8 @@ public class CommitCommentEventView extends GithubEventView<CommitCommentEventPa
 	protected void populateView(GithubEvent event) {
 		ImageView authorAvatar = (ImageView) findViewById(R.id.authorAvatar);
 
-		ImageLoader.getInstance().displayImage(event.actor.avatar_url, authorAvatar);
+        //load the profile image from url with optimal settings
+        handleImage(authorAvatar, event);
 
 		TextView authorName = (TextView) findViewById(R.id.authorName);
 		authorName.setText(event.actor.login);

--- a/app/src/main/java/com/alorma/github/ui/adapter/events/views/CreatedEventView.java
+++ b/app/src/main/java/com/alorma/github/ui/adapter/events/views/CreatedEventView.java
@@ -45,7 +45,8 @@ public class CreatedEventView extends GithubEventView<CreatedEventPayload> {
 
         ImageView authorAvatar = (ImageView) findViewById(R.id.authorAvatar);
 
-        ImageLoader.getInstance().displayImage(event.actor.avatar_url, authorAvatar);
+        //load the profile image from url with optimal settings
+        handleImage(authorAvatar, event);
 
         TextView authorName = (TextView) findViewById(R.id.authorName);
 

--- a/app/src/main/java/com/alorma/github/ui/adapter/events/views/DeleteEventView.java
+++ b/app/src/main/java/com/alorma/github/ui/adapter/events/views/DeleteEventView.java
@@ -38,7 +38,8 @@ public class DeleteEventView extends GithubEventView<DeleteEventPayload> {
     protected void populateView(GithubEvent event) {
         ImageView authorAvatar = (ImageView) findViewById(R.id.authorAvatar);
 
-        ImageLoader.getInstance().displayImage(event.actor.avatar_url, authorAvatar);
+        //load the profile image from url with optimal settings
+        handleImage(authorAvatar, event);
 
         TextView authorName = (TextView) findViewById(R.id.authorName);
 

--- a/app/src/main/java/com/alorma/github/ui/adapter/events/views/ForkEventView.java
+++ b/app/src/main/java/com/alorma/github/ui/adapter/events/views/ForkEventView.java
@@ -44,7 +44,8 @@ public class ForkEventView extends GithubEventView<ForkEventPayload> {
 
 		ImageView authorAvatar = (ImageView) findViewById(R.id.authorAvatar);
 
-		ImageLoader.getInstance().displayImage(event.actor.avatar_url, authorAvatar);
+        //load the profile image from url with optimal settings
+        handleImage(authorAvatar, event);
 
 		TextView authorName = (TextView) findViewById(R.id.authorName);
 		String original = event.repo.name;

--- a/app/src/main/java/com/alorma/github/ui/adapter/events/views/GithubEventView.java
+++ b/app/src/main/java/com/alorma/github/ui/adapter/events/views/GithubEventView.java
@@ -59,7 +59,7 @@ public abstract class GithubEventView<K extends GithubEventPayload> extends Fram
 	protected abstract K convert(Gson gson, String s);
     public void handleImage(ImageView imageView, GithubEvent event) {
         ImageLoader.getInstance().cancelDisplayTask(imageView);
-        DisplayImageOptions displayImageOptions = new DisplayImageOptions.Builder().cacheOnDisk(true).imageScaleType(ImageScaleType.IN_SAMPLE_POWER_OF_2).bitmapConfig(Bitmap.Config.RGB_565).build();
+        DisplayImageOptions displayImageOptions = new DisplayImageOptions.Builder().cacheOnDisk(true).imageScaleType(ImageScaleType.IN_SAMPLE_POWER_OF_2).bitmapConfig(Bitmap.Config.ALPHA_8).build();
         ImageLoader.getInstance().displayImage(event.actor.avatar_url, imageView, displayImageOptions);
     }
 }

--- a/app/src/main/java/com/alorma/github/ui/adapter/events/views/GithubEventView.java
+++ b/app/src/main/java/com/alorma/github/ui/adapter/events/views/GithubEventView.java
@@ -1,12 +1,17 @@
 package com.alorma.github.ui.adapter.events.views;
 
 import android.content.Context;
+import android.graphics.Bitmap;
 import android.util.AttributeSet;
 import android.widget.FrameLayout;
+import android.widget.ImageView;
 
 import com.alorma.github.sdk.bean.dto.response.GithubEvent;
 import com.alorma.github.sdk.bean.dto.response.events.payload.GithubEventPayload;
 import com.google.gson.Gson;
+import com.nostra13.universalimageloader.core.DisplayImageOptions;
+import com.nostra13.universalimageloader.core.ImageLoader;
+import com.nostra13.universalimageloader.core.assist.ImageScaleType;
 
 /**
  * Created by Bernat on 04/10/2014.
@@ -52,4 +57,9 @@ public abstract class GithubEventView<K extends GithubEventPayload> extends Fram
 	}
 
 	protected abstract K convert(Gson gson, String s);
+    public void handleImage(ImageView imageView, GithubEvent event) {
+        ImageLoader.getInstance().cancelDisplayTask(imageView);
+        DisplayImageOptions displayImageOptions = new DisplayImageOptions.Builder().cacheOnDisk(true).imageScaleType(ImageScaleType.IN_SAMPLE_POWER_OF_2).bitmapConfig(Bitmap.Config.RGB_565).build();
+        ImageLoader.getInstance().displayImage(event.actor.avatar_url, imageView, displayImageOptions);
+    }
 }

--- a/app/src/main/java/com/alorma/github/ui/adapter/events/views/IssueCommentEventView.java
+++ b/app/src/main/java/com/alorma/github/ui/adapter/events/views/IssueCommentEventView.java
@@ -40,7 +40,8 @@ public class IssueCommentEventView extends GithubEventView<IssueCommentEventPayl
 	protected void populateView(GithubEvent event) {
 		ImageView authorAvatar = (ImageView) findViewById(R.id.authorAvatar);
 
-		ImageLoader.getInstance().displayImage(event.actor.avatar_url, authorAvatar);
+        //load the profile image from url with optimal settings
+        handleImage(authorAvatar, event);
 
 		TextView authorName = (TextView) findViewById(R.id.authorName);
 		authorName.setText(event.actor.login);

--- a/app/src/main/java/com/alorma/github/ui/adapter/events/views/IssueEventView.java
+++ b/app/src/main/java/com/alorma/github/ui/adapter/events/views/IssueEventView.java
@@ -51,7 +51,8 @@ public class IssueEventView extends GithubEventView<IssueEventPayload> {
 
         ImageView authorAvatar = (ImageView) findViewById(R.id.authorAvatar);
 
-        ImageLoader.getInstance().displayImage(event.actor.avatar_url, authorAvatar);
+        //load the profile image from url with optimal settings
+        handleImage(authorAvatar, event);
 
         TextView authorName = (TextView) findViewById(R.id.authorName);
         authorName.setText(Html.fromHtml(getContext().getResources().getString(textRes, event.actor.login, event.repo.name)));

--- a/app/src/main/java/com/alorma/github/ui/adapter/events/views/PullRequestEventView.java
+++ b/app/src/main/java/com/alorma/github/ui/adapter/events/views/PullRequestEventView.java
@@ -42,7 +42,8 @@ public class PullRequestEventView extends GithubEventView<PullRequestEventPayloa
     protected void populateView(GithubEvent event) {
         ImageView authorAvatar = (ImageView) findViewById(R.id.authorAvatar);
 
-        ImageLoader.getInstance().displayImage(event.actor.avatar_url, authorAvatar);
+        //load the profile image from url with optimal settings
+        handleImage(authorAvatar, event);
 
         TextView authorName = (TextView) findViewById(R.id.authorName);
         authorName.setText(event.actor.login);

--- a/app/src/main/java/com/alorma/github/ui/adapter/events/views/PushEventView.java
+++ b/app/src/main/java/com/alorma/github/ui/adapter/events/views/PushEventView.java
@@ -48,7 +48,8 @@ public class PushEventView extends GithubEventView<PushEventPayload> {
     protected void populateView(GithubEvent event) {
         ImageView authorAvatar = (ImageView) findViewById(R.id.authorAvatar);
 
-        ImageLoader.getInstance().displayImage(event.actor.avatar_url, authorAvatar);
+        //load the profile image from url with optimal settings
+        handleImage(authorAvatar, event);
 
         TextView authorName = (TextView) findViewById(R.id.authorName);
         authorName.setText(event.actor.login);

--- a/app/src/main/java/com/alorma/github/ui/adapter/events/views/ReleaseEventView.java
+++ b/app/src/main/java/com/alorma/github/ui/adapter/events/views/ReleaseEventView.java
@@ -40,7 +40,8 @@ public class ReleaseEventView extends GithubEventView<ReleaseEventPayload> {
     protected void populateView(GithubEvent event) {
         ImageView authorAvatar = (ImageView) findViewById(R.id.authorAvatar);
 
-        ImageLoader.getInstance().displayImage(event.actor.avatar_url, authorAvatar);
+        //load the profile image from url with optimal settings
+        handleImage(authorAvatar, event);
 
         TextView authorName = (TextView) findViewById(R.id.authorName);
 

--- a/app/src/main/java/com/alorma/github/ui/adapter/events/views/UnhandledEventView.java
+++ b/app/src/main/java/com/alorma/github/ui/adapter/events/views/UnhandledEventView.java
@@ -40,7 +40,8 @@ public class UnhandledEventView extends GithubEventView<UnhandledPayload> {
 	protected void populateView(GithubEvent event) {
 		ImageView authorAvatar = (ImageView) findViewById(R.id.authorAvatar);
 
-		ImageLoader.getInstance().displayImage(event.actor.avatar_url, authorAvatar);
+		//load the profile image from url with optimal settings
+		handleImage(authorAvatar, event);
 	}
 
 	@Override

--- a/app/src/main/java/com/alorma/github/ui/adapter/events/views/WatchEventView.java
+++ b/app/src/main/java/com/alorma/github/ui/adapter/events/views/WatchEventView.java
@@ -48,7 +48,8 @@ public class WatchEventView extends GithubEventView<WatchedEventPayload> {
 
         ImageView authorAvatar = (ImageView) findViewById(R.id.authorAvatar);
 
-        ImageLoader.getInstance().displayImage(event.actor.avatar_url, authorAvatar);
+        //load the profile image from url with optimal settings
+        handleImage(authorAvatar, event);
 
         TextView authorName = (TextView) findViewById(R.id.authorName);
         authorName.setText(Html.fromHtml(getContext().getResources().getString(textRes, event.actor.login, event.repo.name)));


### PR DESCRIPTION
* add ViewHolder Pattern (kinda :D) to EventAdapter
 * Add getItemViewType and getViewTypeCount to the Adapter to optimize performance
* move out the logic of the `displayImage` to a new method `handleImage` in the super class which will optimize the image loading and remove some overhead in creating the bitmaps.
 * this improves the performance of the EventsView a lot
* set bitmapConfig to ALPHA_8 which only uses 1 byte per pixel instead of 2 as with RGB_565