### PR TITLE
Fix event filtering on refresh

### DIFF
--- a/app/src/main/java/com/alorma/github/ui/adapter/events/EventAdapter.java
+++ b/app/src/main/java/com/alorma/github/ui/adapter/events/EventAdapter.java
@@ -118,6 +118,15 @@ public class EventAdapter extends LazyAdapter<GithubEvent> {
         }
     }
 
+    @Override
+    public void addAll(Collection<? extends  GithubEvent> collection, boolean paging) {
+        if (!paging) {
+            clear();
+        }
+
+        addAll(collection);
+    }
+
     private boolean checkEventHandled(GithubEvent event) {
         return event.getType() != null && (event.getType() == EventType.PushEvent)
                 || (event.getType() == EventType.WatchEvent)


### PR DESCRIPTION
Unsupported events in the event stream were not filtered properly when doing a refresh by swiping up. The unsupported events were shown in the stream with only a user image and blank content. It was caused by `EventsListFragment` calling the `addAll(collection, paging)` method of the `LazyAdapter` class, which has no item filtering.

This pull request adds the `addAll(collection, paging)` method to the `EventAdapter` class with filtering.