### PR TITLE
Fix #87 Long repo names are cut off

### DIFF
--- a/app/src/main/res/layout/row_repo.xml
+++ b/app/src/main/res/layout/row_repo.xml
@@ -28,8 +28,8 @@
             android:gravity="center"
             android:background="@drawable/private_label"
             android:layout_marginTop="@dimen/gapMedium"
-            android:layout_marginRight="@dimen/gapMedium"
-            android:layout_marginEnd="@dimen/gapMedium"
+            android:layout_marginLeft="@dimen/gapMedium"
+            android:layout_marginStart="@dimen/gapMedium"
             android:layout_alignParentTop="true"
             android:layout_alignParentRight="true"
             android:layout_alignParentEnd="true" />
@@ -39,28 +39,28 @@
             android:layout_height="wrap_content"
             tools:text="Large Text"
             android:id="@+id/repoName"
-            android:layout_alignParentTop="true"
-            android:paddingTop="0dp"
             style="@style/TextAppearance.AppCompat.Headline"
             android:textColor="?colorPrimaryDark"
+            android:layout_alignParentTop="true"
             android:layout_alignParentLeft="true"
             android:layout_alignParentStart="true"
             android:layout_toLeftOf="@+id/infos"
             android:layout_toStartOf="@+id/infos"
             android:fontFamily="sans-serif"
-            android:lines="1" />
+            android:lines="1"
+            android:ellipsize="end" />
 
         <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             style="@style/TextAppearance.AppCompat.Subhead"
-            android:text="Medium Text"
             android:id="@+id/infos"
             android:orientation="vertical"
             android:gravity="center_vertical|right"
             android:layout_below="@+id/repoPrivate"
             android:layout_alignParentRight="true"
-            android:layout_marginRight="@dimen/gapMedium"
+            android:layout_marginLeft="@dimen/gapMedium"
+            android:layout_marginStart="@dimen/gapMedium"
             android:layout_marginTop="@dimen/gapMedium">
 
             <TextView
@@ -96,8 +96,7 @@
             android:layout_alignParentStart="true"
             android:layout_toLeftOf="@+id/infos"
             android:layout_toStartOf="@+id/infos"
-            android:layout_marginTop="@dimen/gapMedium"
-            android:layout_marginRight="@dimen/gapMedium" />
+            android:layout_marginTop="@dimen/gapMedium" />
 
     </RelativeLayout>
 </LinearLayout>


### PR DESCRIPTION
I added left margin to `repoPrivate`, so if it is visible, the `repoName` won't overlap it. I set it for the `infos` layout too and removed right margin from `descriptionText`, because `infos` is always visible and if description is present it could align to it correctly (also `repoName` if `repoPrivate` is not visible).

I also set `ellipsize` for `repoName`. I tried making it two line, but it didn't look appealing to me, as most often the repo names are not separate words, but feature dashes, so the TextView can't carry the name over on to the next line correctly. I can change it if you like.

Finally, I removed the right margin from `repoPrivate` and `infos`, because the outer `RelativeLayout` already has a padding set and there is more space for the name and description that way.

![device-2015-06-29-005820_small](https://cloud.githubusercontent.com/assets/4307918/8398941/d28a6eb0-1e0b-11e5-9cc2-3ef9f3174914.png) ![device-2015-06-29-010003_small](https://cloud.githubusercontent.com/assets/4307918/8398967/a98286a0-1e0c-11e5-82dc-4060e317f57b.png)