### PR TITLE
Some minor fixes

### DIFF
--- a/app/src/main/java/com/alorma/github/ui/activity/MainActivity.java
+++ b/app/src/main/java/com/alorma/github/ui/activity/MainActivity.java
@@ -510,6 +510,8 @@ public class MainActivity extends BaseActivity implements OnMenuItemSelectedList
         } else {
             if (lastUsedFragment instanceof EventsListFragment) {
                 finish();
+            } else if (lastUsedFragment instanceof GeneralReposFragment && resultDrawer != null){
+                resultDrawer.setSelection(0);
             } else {
                 clearFragments();
                 onUserEventsSelected();

--- a/app/src/main/res/layout/activity_issue_detail.xml
+++ b/app/src/main/res/layout/activity_issue_detail.xml
@@ -20,9 +20,7 @@
             android:background="?colorPrimary"
             android:minHeight="?actionBarSize"
             app:contentInsetStart="@dimen/second_keyline"
-            app:layout_scrollFlags="scroll|enterAlways|enterAlwaysCollapsed"
-            app:popupTheme="@style/Toolbar.Popup.AppCompat"
-            app:theme="@style/Toolbar.AppCompat.Responsive" />
+            app:layout_scrollFlags="scroll|enterAlways|enterAlwaysCollapsed" />
     </android.support.design.widget.AppBarLayout>
 
     <android.support.v7.widget.RecyclerView

--- a/app/src/main/res/layout/activity_pullrequest_detail.xml
+++ b/app/src/main/res/layout/activity_pullrequest_detail.xml
@@ -20,9 +20,7 @@
             android:background="?colorPrimary"
             android:minHeight="?actionBarSize"
             app:contentInsetStart="@dimen/second_keyline"
-            app:layout_scrollFlags="scroll|enterAlways|enterAlwaysCollapsed"
-            app:popupTheme="@style/Toolbar.Popup.AppCompat"
-            app:theme="@style/Toolbar.AppCompat.Responsive" />
+            app:layout_scrollFlags="scroll|enterAlways|enterAlwaysCollapsed" />
     </android.support.design.widget.AppBarLayout>
 
     <android.support.v7.widget.RecyclerView


### PR DESCRIPTION
b1f8478 should fix the issue when the Repositories fragment is loaded via the nav drawer and then the back key is pressed (i.e. to close the Repositories list), the drawer selection is still set to Repositories and not Events.

12ecdc8 addresses #135. The menus in the Issues and Pull Request activities now look ok and I didn't see any visual difference in the Toolbar after removing these lines of code, but still more testing might be needed before the issue is closed.