### PR TITLE
Change text to plurals resource if time < 5 sec

### DIFF
--- a/app/src/main/java/com/alorma/github/utils/TimeUtils.java
+++ b/app/src/main/java/com/alorma/github/utils/TimeUtils.java
@@ -66,7 +66,7 @@ public class TimeUtils {
                             if (time > 5) {
                                 text = R.plurals.seconds_ago;
                             } else {
-                                text = R.string.time_ago_just_now;
+                                text = R.plurals.time_just_now;
                             }
                         }
                     }

--- a/app/src/main/res/values/plurals.xml
+++ b/app/src/main/res/values/plurals.xml
@@ -53,7 +53,10 @@
         <item quantity="other">%d minutes ago</item>
     </plurals>
     <plurals name="seconds_ago">
-        <item quantity="one">%d second</item>
-        <item quantity="other">%d seconds</item>
+        <item quantity="one">%d second ago</item>
+        <item quantity="other">%d seconds ago</item>
+    </plurals>
+    <plurals name="time_just_now">
+        <item quantity="other">just now</item>
     </plurals>
 </resources>


### PR DESCRIPTION
We have to provide text as plural resource everywhere, otherwise getQuantityString might crash