### PR TITLE
Fix shortchut typo

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -402,7 +402,7 @@
     <string name="pulls_fragment_title">Pull requests</string>
     <string name="no_pullrequest_ound">No pull requests found</string>
     <string name="navigation_from_orgs">From organizations</string>
-    <string name="action_add_shortcut">Add desktop shortchut</string>
+    <string name="action_add_shortcut">Add desktop shortcut</string>
     <string name="repo_add_to_homescreen">Repository shortcut created</string>
     <string name="issue_add_to_homescreen">Issue shortcut created</string>
     <string name="menu_enable_notifications">Notifications</string>


### PR DESCRIPTION
Fix a tiny typo: shortchut > shortcut.