### PR TITLE
Fixed line breaks in README code blocks

### DIFF
--- a/app/src/main/java/com/alorma/github/ui/fragment/detail/repo/RepoAboutFragment.java
+++ b/app/src/main/java/com/alorma/github/ui/fragment/detail/repo/RepoAboutFragment.java
@@ -304,7 +304,7 @@ public class RepoAboutFragment extends Fragment
                     }
                 }
             });
-            htmlContentView.loadData(htmlContent, "text/html; charset=UTF-8", "UTF-8");
+            htmlContentView.loadDataWithBaseURL(null, htmlContent, "text/html", "UTF-8", null);
 
             loadingHtml.setVisibility(View.GONE);
 


### PR DESCRIPTION
Changed WebView `loadData()` to `loadDataWithBaseURL()` so that line breaks in `<pre>` blocks rendered by GitHub's Markdown rendering API display properly in the README WebView on the repo detail page.

See [https://code.google.com/p/android/issues/detail?id=6965](https://code.google.com/p/android/issues/detail?id=6965) for a more detailed description. `loadData()` requires URI escaping since it uses the `data:` schema.
