### PR TITLE
Testing GitskariosUriManager.getRepoInfo()

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -239,6 +239,7 @@ dependencies {
   compile 'com.github.florent37:glidepalette:1.0.4@aar'
 
   compile 'cat.ereza:customactivityoncrash:1.4.0'
+  compile 'io.mola.galimatias:galimatias:0.2.0'
 
   testCompile 'junit:junit:4.12'
   testCompile 'org.assertj:assertj-core:1.7.0'

--- a/app/src/main/java/com/alorma/github/GitskariosUriManager.java
+++ b/app/src/main/java/com/alorma/github/GitskariosUriManager.java
@@ -9,28 +9,29 @@ import com.alorma.github.sdk.bean.info.IssueInfo;
 import com.alorma.github.sdk.bean.info.ReleaseInfo;
 import com.alorma.github.sdk.bean.info.RepoInfo;
 
+import io.mola.galimatias.GalimatiasParseException;
+import io.mola.galimatias.URL;
+
 public class GitskariosUriManager {
 
   @NonNull
-  public RepoInfo getRepoInfo(Uri uri) {
+  public RepoInfo getRepoInfo(String url) throws GalimatiasParseException {
     RepoInfo repoInfo = new RepoInfo();
 
-    repoInfo.owner = uri.getPathSegments().get(0);
-    repoInfo.name = uri.getPathSegments().get(1);
+    URL parsedUrl = URL.parse(url);
+    repoInfo.owner = parsedUrl.pathSegments().get(0);
+    repoInfo.name = parsedUrl.pathSegments().get(1);
 
-    /*
-    // TODO Branches
-    if (uriMatcher.match(uri) == URI_REPO_BRANCH) {
-      repoInfo.branch = uri.getLastPathSegment();
-    } else if (uriMatcher.match(uri) == URI_REPO_BRANCH_FEATURE
-        || uriMatcher.match(uri) == URI_REPO_BRANCH_RELEASE
-        || uriMatcher.match(uri) == URI_REPO_BRANCH_HOTFIX) {
-      repoInfo.branch = uri.getPathSegments().get(3) + "/" + uri.getPathSegments().get(4);
-    }
-    */
-
-    repoInfo.permissions = null;
     return repoInfo;
+  }
+
+  @NonNull
+  public RepoInfo getRepoInfo(Uri uri) {
+      try {
+          return getRepoInfo(uri.toString());
+      } catch (GalimatiasParseException e) {
+          return null;
+      }
   }
 
   @NonNull

--- a/app/src/test/java/com/alorma/github/GitskariosUriManagerTest.java
+++ b/app/src/test/java/com/alorma/github/GitskariosUriManagerTest.java
@@ -6,6 +6,8 @@ import com.alorma.github.sdk.bean.info.RepoInfo;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.mola.galimatias.GalimatiasParseException;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -19,12 +21,12 @@ public class GitskariosUriManagerTest {
   }
 
   @Test
-  public void shouldGiveGitskariosValues_whenParsingGitskariosUrl() {
+  public void shouldGiveGitskariosValues_whenParsingGitskariosUrl() throws GalimatiasParseException {
     // given
     String uri = "https://github.com/gitskarios/Gitskarios";
 
     // when
-    RepoInfo repoInfo = urisManager.getRepoInfo(Uri.parse(uri));
+    RepoInfo repoInfo = urisManager.getRepoInfo(uri);
 
     //then
     assertEquals(repoInfo.owner, "gitskarios");

--- a/app/src/test/java/com/alorma/github/GitskariosUriManagerTest.java
+++ b/app/src/test/java/com/alorma/github/GitskariosUriManagerTest.java
@@ -1,4 +1,4 @@
-package com.alorma.github.cache;
+package com.alorma.github;
 
 import android.net.Uri;
 import com.alorma.github.GitskariosUriManager;

--- a/app/src/test/java/com/alorma/github/GitskariosUriManagerTest.java
+++ b/app/src/test/java/com/alorma/github/GitskariosUriManagerTest.java
@@ -27,7 +27,6 @@ public class GitskariosUriManagerTest {
     RepoInfo repoInfo = urisManager.getRepoInfo(Uri.parse(uri));
 
     //then
-    assertNotNull(repoInfo);
     assertEquals(repoInfo.owner, "gitskarios");
     assertEquals(repoInfo.name, "Gitskarios");
   }

--- a/app/src/test/java/com/alorma/github/GitskariosUriManagerTest.java
+++ b/app/src/test/java/com/alorma/github/GitskariosUriManagerTest.java
@@ -19,7 +19,7 @@ public class GitskariosUriManagerTest {
   }
 
   @Test
-  public void extractRepoInfoTest() {
+  public void shouldGiveGitskariosValues_whenParsingGitskariosUrl() {
     // given
     String uri = "https://github.com/gitskarios/Gitskarios";
 


### PR DESCRIPTION
To test getRepoInfo(), we created a new one that uses String instead of Android's Uri.
