### PR TITLE
Fix for issue #349

### DIFF
--- a/app/src/main/java/com/alorma/github/ui/activity/MainActivity.java
+++ b/app/src/main/java/com/alorma/github/ui/activity/MainActivity.java
@@ -197,7 +197,6 @@ public class MainActivity extends BaseActivity
         selectedAccount = accountList.get(0);
         createDrawer();
         selectAccount(selectedAccount);
-        onUserEventsSelected();
       }
     }
   }
@@ -469,13 +468,6 @@ public class MainActivity extends BaseActivity
 
     if (changingUser) {
       lastUsedFragment = null;
-      clearFragments();
-    }
-  }
-
-  private void clearFragments() {
-    if (getSupportFragmentManager() != null) {
-      getSupportFragmentManager().popBackStack(null, FragmentManager.POP_BACK_STACK_INCLUSIVE);
     }
   }
 
@@ -582,7 +574,6 @@ public class MainActivity extends BaseActivity
 
   @Override
   public boolean onReposSelected() {
-    clearFragments();
     setFragment(GeneralReposFragment.newInstance(), false);
     return true;
   }
@@ -603,7 +594,7 @@ public class MainActivity extends BaseActivity
   public boolean onUserEventsSelected() {
     String user = new StoreCredentials(this).getUserName();
     if (user != null) {
-      setFragment(EventsListFragment.newInstance(user));
+      setFragment(EventsListFragment.newInstance(user), false);
     }
     return true;
   }
@@ -664,8 +655,6 @@ public class MainActivity extends BaseActivity
       } else if (resultDrawer != null && (lastUsedFragment instanceof GeneralReposFragment
           || lastUsedFragment instanceof GeneralPeopleFragment)) {
         resultDrawer.setSelection(R.id.nav_drawer_events);
-        clearFragments();
-        onUserEventsSelected();
       }
     }
   }


### PR DESCRIPTION
**Changes in MainActivity:**
- `createDrawer()` at the end of this method there is code `resultDrawer.setSelection(R.id.nav_drawer_events);` this code causes call to `OnDrawerItemClickListener.onItemClick(View, position, IDrawerItem)` in result `onUserEventsSelected()` method is called and `EventsListFragment` is displayed to user, so there is no need to call `onUserEventsSelected()` after  `createDrawer()`
- `setFragment(EventsListFragment.newInstance(user), false);` this piece of code resolves whole issue :)
- if we do not add fragments to backstack there is no need to clear them from backstack

**Please correct me if I'm wrong somewhere.**
