### PR TITLE
Fix user.blog URL logic

### DIFF
--- a/app/src/main/java/com/alorma/github/ui/fragment/users/UserResumeFragment.java
+++ b/app/src/main/java/com/alorma/github/ui/fragment/users/UserResumeFragment.java
@@ -107,7 +107,7 @@ public class UserResumeFragment extends BaseFragment implements TitleProvider {
     }
     if (!TextUtils.isEmpty(user.blog)) {
       Intent intent = new Intent(Intent.ACTION_VIEW);
-      if (!user.blog.startsWith("http://") || !user.blog.startsWith("https://")) {
+      if (!user.blog.startsWith("http://") && !user.blog.startsWith("https://")) {
         user.blog = "http://" + user.blog;
       }
       intent.setData(Uri.parse(user.blog));


### PR DESCRIPTION
Should be `if (not http and not https)`.

This fixes up the fix for #368, which caused all profile URLs to have `http://` prepended to them (behavior in current release of app).

Thanks!
