### PR TITLE
Fixed the height of the row_gist

### DIFF
--- a/app/src/main/res/layout/row_gist.xml
+++ b/app/src/main/res/layout/row_gist.xml
@@ -2,7 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               xmlns:tools="http://schemas.android.com/tools"
               android:layout_width="match_parent"
-              android:layout_height="match_parent"
+              android:layout_height="wrap_content"
               android:background="?selectableItemBackground"
               android:orientation="vertical"
               android:padding="@dimen/gapLarge"


### PR DESCRIPTION
The row_gist uses `android:layout_height="match_parent"` which uses all the screen height for every item on the list.

![screenshot_20160407-033317](https://cloud.githubusercontent.com/assets/6932449/14337847/efcfe492-fc71-11e5-8167-c1111dd1d78e.png)

![screenshot_20160407-033325](https://cloud.githubusercontent.com/assets/6932449/14337849/fb3da512-fc71-11e5-967d-6a1b677fb764.png)

I've replaced it with `android:layout_height="wrap_content"`

![screenshot_20160407-033231](https://cloud.githubusercontent.com/assets/6932449/14337854/16f43d0c-fc72-11e5-90c6-98045775b48f.png)
