### PR TITLE
Automatically lower the keyboard when in inner-dialoges. fixes #408

### DIFF
--- a/app/src/github/java/com/alorma/github/ui/activity/WelcomeActivity.java
+++ b/app/src/github/java/com/alorma/github/ui/activity/WelcomeActivity.java
@@ -2,7 +2,6 @@ package com.alorma.github.ui.activity;
 
 import android.accounts.AccountAuthenticatorActivity;
 import android.app.Activity;
-import android.content.Context;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.StringRes;
@@ -12,13 +11,15 @@ import android.text.InputType;
 import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.view.View;
-import android.view.inputmethod.InputMethodManager;
 import android.widget.Toast;
-import butterknife.Bind;
-import butterknife.ButterKnife;
+
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.alorma.github.R;
 import com.alorma.github.sdk.bean.dto.response.User;
+import com.alorma.github.utils.KeyboardUtils;
+
+import butterknife.Bind;
+import butterknife.ButterKnife;
 
 public class WelcomeActivity extends AccountAuthenticatorActivity
     implements WelcomePresenterViewInterface {
@@ -29,6 +30,7 @@ public class WelcomeActivity extends AccountAuthenticatorActivity
   @Bind(R.id.progressBar) View progressBar;
   private WelcomePresenter welcomePresenter;
   private SMSBroadcastReceiver smsBroadcastReceiver;
+  private MaterialDialog dialog;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -84,7 +86,7 @@ public class WelcomeActivity extends AccountAuthenticatorActivity
   }
 
   private void show2faDialog(@StringRes int message) {
-    new MaterialDialog.Builder(this).title(R.string.write_otp_code_title)
+    dialog = new MaterialDialog.Builder(this).title(R.string.write_otp_code_title)
         .content(message)
         .input(getString(R.string.write_otp_code_hint), null, false, (dialog, input) -> {
           welcomePresenter.setOtpCode(String.valueOf(input));
@@ -110,8 +112,9 @@ public class WelcomeActivity extends AccountAuthenticatorActivity
   public void didLogin() {
     progressBar.setVisibility(View.GONE);
     buttonLogin.setEnabled(true);
-    InputMethodManager imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
-    imm.hideSoftInputFromWindow(buttonLogin.getWindowToken(), 0);
+    if (buttonLogin != null) {
+      KeyboardUtils.lowerKeyboard(this);
+    }
   }
 
   private class ButtonEnablerTextWatcher implements TextWatcher {
@@ -153,6 +156,14 @@ public class WelcomeActivity extends AccountAuthenticatorActivity
   protected void onStart() {
     super.onStart();
     welcomePresenter.start(this);
+  }
+
+  @Override
+  protected void onPause() {
+    super.onPause();
+    if (dialog != null && dialog.isShowing()) {
+      KeyboardUtils.lowerKeyboard(this);
+    }
   }
 
   @Override

--- a/app/src/github/java/com/alorma/github/ui/fragment/donate/DonateFragment.java
+++ b/app/src/github/java/com/alorma/github/ui/fragment/donate/DonateFragment.java
@@ -14,15 +14,18 @@ import android.support.annotation.Nullable;
 import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.Toast;
+
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.alorma.github.R;
 import com.alorma.github.ui.fragment.base.BaseFragment;
 import com.android.vending.billing.IInAppBillingService;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import org.json.JSONException;
-import org.json.JSONObject;
 
 /**
  * Created by a557114 on 25/07/2015.
@@ -67,7 +70,7 @@ public class DonateFragment extends BaseFragment {
   }
 
   public void launchDonate() {
-    new MaterialDialog.Builder(getActivity()).title(R.string.support_development)
+    dialog = new MaterialDialog.Builder(getActivity()).title(R.string.support_development)
         .adapter(new DonateItemsAdapter(getActivity(), skuList), new MaterialDialog.ListCallback() {
           @Override
           public void onSelection(MaterialDialog materialDialog, View view, int i,

--- a/app/src/main/java/com/alorma/github/ui/activity/ContentEditorActivity.java
+++ b/app/src/main/java/com/alorma/github/ui/activity/ContentEditorActivity.java
@@ -270,7 +270,7 @@ public class ContentEditorActivity extends BackActivity
   }
 
   private void showAddPicture() {
-    new MaterialDialog.Builder(this).title(R.string.addPicture)
+    dialog = new MaterialDialog.Builder(this).title(R.string.addPicture)
         .content(R.string.addPictureContent)
         .input(R.string.addPictureHint, 0, false, new MaterialDialog.InputCallback() {
           @Override

--- a/app/src/main/java/com/alorma/github/ui/activity/IssueDetailActivity.java
+++ b/app/src/main/java/com/alorma/github/ui/activity/IssueDetailActivity.java
@@ -18,6 +18,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.animation.AccelerateDecelerateInterpolator;
 import android.widget.ProgressBar;
+
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.alorma.github.GitskariosSettings;
 import com.alorma.github.R;
@@ -61,9 +62,11 @@ import com.nineoldandroids.animation.Animator;
 import com.nineoldandroids.animation.AnimatorSet;
 import com.nineoldandroids.animation.ArgbEvaluator;
 import com.nineoldandroids.animation.ValueAnimator;
-import io.fabric.sdk.android.Fabric;
+
 import java.util.ArrayList;
 import java.util.List;
+
+import io.fabric.sdk.android.Fabric;
 import rx.Observer;
 import rx.Subscriber;
 import rx.android.schedulers.AndroidSchedulers;
@@ -354,7 +357,7 @@ public class IssueDetailActivity extends BackActivity
         finish();
       }
     });
-    builder.show();
+    dialog = builder.show();
   }
 
   @Override
@@ -486,7 +489,7 @@ public class IssueDetailActivity extends BackActivity
 
   @Override
   public void onTitleEditRequest() {
-    new MaterialDialog.Builder(this).title(R.string.edit_issue_title)
+    dialog = new MaterialDialog.Builder(this).title(R.string.edit_issue_title)
         .input(null, issueStory.item.title, false, new MaterialDialog.InputCallback() {
           @Override
           public void onInput(MaterialDialog materialDialog, CharSequence charSequence) {
@@ -808,7 +811,7 @@ public class IssueDetailActivity extends BackActivity
           //                        super.onNeutral(dialog);
           //                    }
         });
-        builder.show();
+        dialog = builder.show();
       }
     }
 

--- a/app/src/main/java/com/alorma/github/ui/activity/NewIssueActivity.java
+++ b/app/src/main/java/com/alorma/github/ui/activity/NewIssueActivity.java
@@ -395,7 +395,7 @@ public class NewIssueActivity extends BackActivity {
         setAssigneeUser(null);
       }
     });
-    builder.show();
+    dialog = builder.show();
   }
 
   private void setAssigneeUser(User user) {
@@ -494,7 +494,7 @@ public class NewIssueActivity extends BackActivity {
       }
     }).negativeText(R.string.cancel);
 
-    builder.show();
+    dialog = builder.show();
   }
 
   private void createMilestone(String milestoneName) {
@@ -604,7 +604,7 @@ public class NewIssueActivity extends BackActivity {
           setLabels(null);
         }
       });
-      builder.show();
+      dialog = builder.show();
     }
   }
 

--- a/app/src/main/java/com/alorma/github/ui/activity/base/BaseActivity.java
+++ b/app/src/main/java/com/alorma/github/ui/activity/base/BaseActivity.java
@@ -9,8 +9,12 @@ import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
+
+import com.afollestad.materialdialogs.MaterialDialog;
 import com.alorma.github.R;
 import com.alorma.github.ui.activity.AccountsManager;
+import com.alorma.github.utils.KeyboardUtils;
+
 import java.util.List;
 
 public class BaseActivity extends AppCompatActivity {
@@ -20,6 +24,8 @@ public class BaseActivity extends AppCompatActivity {
   private Toolbar toolbar;
   private AccountsManager accountsManager;
   private ProgressDialog progressDialog;
+  protected MaterialDialog dialog;
+
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -113,6 +119,14 @@ public class BaseActivity extends AppCompatActivity {
       } catch (Exception e) {
         e.printStackTrace();
       }
+    }
+  }
+
+  @Override
+  public void onPause() {
+    super.onPause();
+    if (dialog != null && dialog.isShowing()) {
+      KeyboardUtils.lowerKeyboard(this);
     }
   }
 

--- a/app/src/main/java/com/alorma/github/ui/activity/gists/CreateGistActivity.java
+++ b/app/src/main/java/com/alorma/github/ui/activity/gists/CreateGistActivity.java
@@ -162,7 +162,7 @@ public class CreateGistActivity extends BackActivity
         finish();
       }
     });
-    builder.show();
+    dialog = builder.show();
   }
 
   private void showDialogCancelGist() {
@@ -184,7 +184,7 @@ public class CreateGistActivity extends BackActivity
         publishGist();
       }
     });
-    builder.show();
+    dialog = builder.show();
   }
 
   private void publishGist() {
@@ -246,6 +246,6 @@ public class CreateGistActivity extends BackActivity
         adapter.remove(item);
       }
     });
-    builder.show();
+    dialog = builder.show();
   }
 }

--- a/app/src/main/java/com/alorma/github/ui/activity/gists/GistEditorActivity.java
+++ b/app/src/main/java/com/alorma/github/ui/activity/gists/GistEditorActivity.java
@@ -134,7 +134,7 @@ public class GistEditorActivity extends BackActivity {
         endGistFile();
       }
     });
-    builder.show();
+    dialog = builder.show();
   }
 
   private void endGistFile() {

--- a/app/src/main/java/com/alorma/github/ui/callbacks/DialogBranchesSubscriber.java
+++ b/app/src/main/java/com/alorma/github/ui/callbacks/DialogBranchesSubscriber.java
@@ -24,7 +24,7 @@ public abstract class DialogBranchesSubscriber extends BranchesSubscriber
         builder.autoDismiss(true);
         builder.items(branches);
         builder.itemsCallbackSingleChoice(defaultBranchPosition, this);
-        builder.build().show();
+
       } else if (branches.length == 1) {
         onBranchSelected(branches[0]);
       } else {

--- a/app/src/main/java/com/alorma/github/ui/fragment/base/BaseFragment.java
+++ b/app/src/main/java/com/alorma/github/ui/fragment/base/BaseFragment.java
@@ -1,10 +1,24 @@
 package com.alorma.github.ui.fragment.base;
 
+import android.app.Activity;
 import android.support.v4.app.Fragment;
+
+import com.afollestad.materialdialogs.MaterialDialog;
+import com.alorma.github.utils.KeyboardUtils;
 
 /**
  * Created by Bernat on 12/08/2014.
  */
 public class BaseFragment extends Fragment {
+    protected MaterialDialog dialog;
 
+    @Override
+    public void onPause() {
+        super.onPause();
+        Activity activity = getActivity();
+        if (dialog != null && dialog.isShowing() &&
+                getActivity() != null && activity.getWindow() != null) {
+            KeyboardUtils.lowerKeyboard(activity);
+        }
+    }
 }

--- a/app/src/main/java/com/alorma/github/ui/fragment/pullrequest/PullRequestConversationFragment.java
+++ b/app/src/main/java/com/alorma/github/ui/fragment/pullrequest/PullRequestConversationFragment.java
@@ -7,7 +7,6 @@ import android.graphics.Color;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.v4.app.Fragment;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -17,6 +16,7 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.alorma.github.GitskariosSettings;
 import com.alorma.github.R;
@@ -41,16 +41,18 @@ import com.alorma.github.ui.ErrorHandler;
 import com.alorma.github.ui.actions.AddIssueCommentAction;
 import com.alorma.github.ui.activity.ContentEditorActivity;
 import com.alorma.github.ui.adapter.issues.PullRequestDetailAdapter;
+import com.alorma.github.ui.fragment.base.BaseFragment;
 import com.alorma.github.ui.listeners.IssueDetailRequestListener;
 import com.alorma.github.ui.view.pullrequest.PullRequestDetailView;
 import com.alorma.github.utils.IssueUtils;
 import com.mikepenz.iconics.IconicsDrawable;
 import com.mikepenz.octicons_typeface_library.Octicons;
+
 import rx.Subscriber;
 import rx.android.schedulers.AndroidSchedulers;
 import rx.schedulers.Schedulers;
 
-public class PullRequestConversationFragment extends Fragment
+public class PullRequestConversationFragment extends BaseFragment
     implements PullRequestDetailView.PullRequestActionsListener, IssueDetailRequestListener,
     SwipeRefreshLayout.OnRefreshListener {
 
@@ -383,7 +385,7 @@ public class PullRequestConversationFragment extends Fragment
           merge(charSequence.toString(), head.sha, issueInfo);
         });
     builder.inputType(InputType.TYPE_CLASS_TEXT);
-    builder.show();
+    dialog = builder.show();
   }
 
   private void merge(String message, String sha, IssueInfo issueInfo) {

--- a/app/src/main/java/com/alorma/github/utils/KeyboardUtils.java
+++ b/app/src/main/java/com/alorma/github/utils/KeyboardUtils.java
@@ -1,0 +1,41 @@
+package com.alorma.github.utils;
+
+import android.app.Activity;
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.view.View;
+import android.view.inputmethod.InputMethodManager;
+
+/**
+ * Utility static methods for keyboard related functions.
+ * <p>
+ * Created by Daniel Watson on 5/14/16.
+ */
+public class KeyboardUtils {
+
+    /**
+     * Lower a keyboard owned by an activity window.
+     *
+     * @param activity  Current visible instance of activity window
+     */
+    public static void lowerKeyboard(@NonNull Activity activity) {
+        if (activity.getWindow() != null) {
+            View decorView = activity.getWindow().getDecorView();
+            lowerKeyboard(activity, decorView);
+        }
+    }
+
+    /**
+     * Lower an IEM keyboard that has been raised with a view such as dialog.
+     *
+     * @param applicationContext   Context of application
+     * @param focusView View that owns keyboard.
+     */
+    public static void lowerKeyboard(@NonNull Context applicationContext, View focusView) {
+        if (focusView != null && focusView.getWindowToken() != null) {
+            InputMethodManager imm = (InputMethodManager)
+                    applicationContext.getSystemService(Context.INPUT_METHOD_SERVICE);
+            imm.hideSoftInputFromWindow(focusView.getWindowToken(), 0);
+        }
+    }
+}


### PR DESCRIPTION
- Assign MaterialDialog instances to the base fragment and activity instances.
- Add KeyboardUtils that allows the keyboard to be lowered multiple ways.
- Add onPause() methods to base fragment and activity to call lowering of keyboard.
- Did not touch Rx Action and subscriber classes as this probably needs to be thought about with a separate async contract.
- Apologies for the auto import formatting and 4 space indentation.
